### PR TITLE
Fix game size to avoid size+1 games

### DIFF
--- a/pytron/game.py
+++ b/pytron/game.py
@@ -90,7 +90,7 @@ class PytronEngine:
         for bot_id, (position, _) in enumerate(next_position_and_orientation):
             # if someone goes outside of the board, it lose
             row, col = position
-            if not 0 <= row <= self.n_rows or not 0 <= col <= self.n_columns:
+            if not 0 <= row < self.n_rows or not 0 <= col < self.n_columns:
                 self.dead_bots.add(bot_id)
 
             # if someone crash some tail, it lose


### PR DESCRIPTION
If you use --size=20, the code is checking the valid positions
between 0 and 20 included, that is a size of 21.

This commit fixes this problem and in the example checks from 0 to 19