### PR TITLE
Fix orientation calculation

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ if a bot starts in position (1, 1), and moves to (1, 2), and another bot starts 
     [(3, 2), (2 2)],  # second bot
 ]
 ```
-The positions are read as (row_number, column_number).
+The positions are read as (column_number, row_number).
 
 - `bots_orientation`: the orientation of each bot, which means it will be the direction
 where it will move if the returend action is `Forward`. The possible values are

--- a/pytron/game.py
+++ b/pytron/game.py
@@ -8,10 +8,12 @@ from itertools import zip_longest
 from pytron.bot import Orientation
 
 POSSIBLE_DELTAS = {
-    Orientation.North: (-1, 0),
-    Orientation.East: (0, 1),
-    Orientation.South: (1, 0),
-    Orientation.West: (0, -1),
+                    #   x   y
+                    #  col row
+    Orientation.North: (0, -1),
+    Orientation.East:  (1,  0),
+    Orientation.South: (0,  1),
+    Orientation.West: (-1,  0),
 }
 
 
@@ -24,7 +26,7 @@ class GameState:
             while True:
                 row_number = random.randint(1, n_rows - 1)
                 col_number = random.randint(1, n_columns - 1)
-                position = (row_number, col_number)
+                position = (col_number, row_number)
                 if position not in self.used_positions:
                     break
             self.bots_path.append([position])


### PR DESCRIPTION
Coordinates tuples are read as (`x`, `y`) but the game engine stored swapped indexes (`row_number`, `column_number`). So the game was seen like _rotated_.

This PR fixes coordinates tuples (`x` is `column_number` and `y` is `row_number`) and orientation deltas (ie. going North means decrementing `y`/`row` coordinate).
